### PR TITLE
Change build dir for :common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.DS_Store

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+/gradle-build

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'android-library'
 
+layout.setBuildDirectory("$projectDir/gradle-build")
+
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))


### PR DESCRIPTION
When building with gradle, you have to delete the BUILD file temporarily because the default build directory is "/build"
Switching to "/gradle-build" fixes this